### PR TITLE
feat: add inital xsession

### DIFF
--- a/startunicorn
+++ b/startunicorn
@@ -1,0 +1,21 @@
+#!/usr/bin/bash
+
+BASE_XFCE_DIR="$HOME/.config/xfce4/"
+BASE_UNICORN_DIR="$HOME/.config/unicorn/"
+
+# In case user doesn't have their configs
+if ! [[ -d "$BASE_UNICORN_DIR" ]]; then
+  mkdir -p "$BASE_UNICORN_DIR"
+  cp -r /etc/xdg/unicorn $BASE_UNICORN_DIR
+fi
+
+# Replace config
+mv -f $BASE_XFCE_DIR $HOME/.config/xfce4_old
+cp -r $BASE_UNICORN_DIR $BASE_XFCE_DIR
+
+/usr/bin/startxfce4
+
+# Revert configs after
+rm -rf $HOME/.config/xfce4
+mv -f $HOME/.config/xfce4_old $BASE_XFCE_DIR
+exit 0

--- a/unicorn.desktop
+++ b/unicorn.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Name=Unicorn Session
+Comment=Use this session to run Unicorn as your desktop environment
+Exec=startunicorn
+Icon=
+Type=Application
+DesktopNames=XFCE


### PR DESCRIPTION
`unicorn.desktop` should be in `/usr/share/xsession` and `startunicorn` under `/usr/bin`. The `xfce4` directory should now be in `/etc/xdg/unicorn` and the script should (**have not tested**) add unicorn to the users home from there (`/etc/xdg/unicorn`) if needed. The other dotfiles still need to be added.